### PR TITLE
Fix GH integration in Slack

### DIFF
--- a/lib/lita/handlers/reviewme.rb
+++ b/lib/lita/handlers/reviewme.rb
@@ -46,14 +46,14 @@ module Lita
       )
 
       route(
-        %r{review (?<url>(https://)?github.com/(?<repo>.+)/(pull|issues)/(?<id>\d+))}i,
+        %r{review <?(?<url>(https://)?github.com/(?<repo>.+)/(pull|issues)/(?<id>\d+))>?}i,
         :comment_on_github,
         command: true,
         help: { "review https://github.com/user/repo/pull/123" => "adds comment to GH issue requesting review" },
       )
 
       route(
-        %r{review (https?://(?!github.com).*)}i,
+        %r{review <?(https?://(?!github.com).*)>?}i,
         :mention_reviewer,
         command: true,
         help: { "review http://some-non-github-url.com" => "requests review of the given URL in chat" }

--- a/spec/lita/handlers/reviewme_spec.rb
+++ b/spec/lita/handlers/reviewme_spec.rb
@@ -8,8 +8,10 @@ describe Lita::Handlers::Reviewme, lita_handler: true do
   it { is_expected.to route_command("reviewers").to :display_reviewers }
   it { is_expected.to route_command("review me").to :generate_assignment }
   it { is_expected.to route_command("review https://github.com/user/repo/pull/123").to :comment_on_github }
+  it { is_expected.to route_command("review <https://github.com/user/repo/pull/123>").to :comment_on_github }
   it { is_expected.to route_command("review https://github.com/user/repo/issues/123").to :comment_on_github }
   it { is_expected.to route_command("review https://bitbucket.org/user/repo/pull-requests/123").to :mention_reviewer }
+  it { is_expected.to route_command("review <https://bitbucket.org/user/repo/pull-requests/123>").to :mention_reviewer }
 
   let(:reply) { replies.last }
 


### PR DESCRIPTION
The GH integration feature doesn't work in Slack. The working theory is that Slack inserts `<``>` around URLs in messages, therefore the messages aren't matching in the handler.