### PR TITLE
Make "@" implicit for GH integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,25 +29,25 @@ ENV["GITHUB_WOLFBRAIN_ACCESS_TOKEN"]
 
 > **Jay H.** Nerdbot: reviewers
 >
-> **Nerdbot** @iamvery, @zacstewart, ...
+> **Nerdbot** iamvery, zacstewart, ...
 
 ### Add a name to the review rotation
 
-> **Jay H.** Nerdbot: add @kyfast to reviews
+> **Jay H.** Nerdbot: add kyfast to reviews
 >
-> **Nerdbot** added @kyfast to reviews
+> **Nerdbot** added kyfast to reviews
 
 ### Remove a name from the review rotation
 
-> **Jay H.** Nerdbot: remove @kyfast from reviews
+> **Jay H.** Nerdbot: remove kyfast from reviews
 >
-> **Nerdbot** removed @kyfast from reviews
+> **Nerdbot** removed kyfast from reviews
 
 ### Fetch the next reviewer
 
 > **Jay H.** Nerdbot: review me
 >
-> **Nerdbot** @iamvery
+> **Nerdbot** iamvery
 
 ### Comment on a Github pull request or issue
 This will post a comment mentioning the next reviewer on the referenced Github
@@ -56,7 +56,7 @@ to the repository.
 
 > **Jay H.** Nerdbot: review https://github.com/iamvery/lita-reviewme/issues/7
 >
-> **Nerdbot** @iamvery should be on it...
+> **Nerdbot** iamvery should be on it...
 
 ## License
 

--- a/lib/lita/handlers/reviewme.rb
+++ b/lib/lita/handlers/reviewme.rb
@@ -109,7 +109,7 @@ module Lita
       end
 
       def github_comment(reviewer)
-        ":eyes: #{reviewer}"
+        ":eyes: @#{reviewer}"
       end
 
       def github_client

--- a/lib/lita/handlers/reviewme.rb
+++ b/lib/lita/handlers/reviewme.rb
@@ -15,7 +15,7 @@ module Lita
         /add reviewer (.+)/i,
         :add_reviewer,
         command: true,
-        help: { "add reviewer @iamvery" => "adds @iamvery to the reviewer rotation" },
+        help: { "add reviewer iamvery" => "adds iamvery to the reviewer rotation" },
       )
 
       route(
@@ -28,7 +28,7 @@ module Lita
         /remove reviewer (.+)/i,
         :remove_reviewer,
         command: true,
-        help: { "remove reviewer @iamvery" => "removes @iamvery from the reviewer rotation" },
+        help: { "remove reviewer iamvery" => "removes iamvery from the reviewer rotation" },
       )
 
       route(

--- a/spec/lita/handlers/reviewme_spec.rb
+++ b/spec/lita/handlers/reviewme_spec.rb
@@ -59,10 +59,10 @@ describe Lita::Handlers::Reviewme, lita_handler: true do
       expect_any_instance_of(Octokit::Client).to receive(:add_comment)
         .with(repo, id, ":eyes: @iamvery")
 
-      send_command("add @iamvery to reviews")
+      send_command("add iamvery to reviews")
       send_command("review https://github.com/#{repo}/pull/#{id}")
 
-      expect(replies.last).to eq("@iamvery should be on it...")
+      expect(replies.last).to eq("iamvery should be on it...")
     end
 
     it "handles errors gracefully" do

--- a/spec/lita/handlers/reviewme_spec.rb
+++ b/spec/lita/handlers/reviewme_spec.rb
@@ -1,10 +1,10 @@
 require "spec_helper"
 
 describe Lita::Handlers::Reviewme, lita_handler: true do
-  it { is_expected.to route_command("add @iamvery to reviews").to :add_reviewer }
-  it { is_expected.to route_command("add reviewer @iamvery").to :add_reviewer }
-  it { is_expected.to route_command("remove @iamvery from reviews").to :remove_reviewer }
-  it { is_expected.to route_command("remove reviewer @iamvery").to :remove_reviewer }
+  it { is_expected.to route_command("add iamvery to reviews").to :add_reviewer }
+  it { is_expected.to route_command("add reviewer iamvery").to :add_reviewer }
+  it { is_expected.to route_command("remove iamvery from reviews").to :remove_reviewer }
+  it { is_expected.to route_command("remove reviewer iamvery").to :remove_reviewer }
   it { is_expected.to route_command("reviewers").to :display_reviewers }
   it { is_expected.to route_command("review me").to :generate_assignment }
   it { is_expected.to route_command("review https://github.com/user/repo/pull/123").to :comment_on_github }
@@ -17,37 +17,37 @@ describe Lita::Handlers::Reviewme, lita_handler: true do
 
   describe "#add_reviewer" do
     it "adds a name to the list" do
-      send_command("add @iamvery to reviews")
+      send_command("add iamvery to reviews")
 
-      expect(reply).to eq("added @iamvery to reviews")
+      expect(reply).to eq("added iamvery to reviews")
     end
   end
 
   describe "#remove_reviewer" do
     it "removes a name from the list" do
-      send_command("remove @iamvery from reviews")
+      send_command("remove iamvery from reviews")
 
-      expect(reply).to eq("removed @iamvery from reviews")
+      expect(reply).to eq("removed iamvery from reviews")
     end
   end
 
   describe "#generate_assignment" do
     it "responds with the next reviewer's name" do
-      send_command("add @iamvery to reviews")
+      send_command("add iamvery to reviews")
       send_command("review me")
 
-      expect(reply).to eq("@iamvery")
+      expect(reply).to eq("iamvery")
     end
 
     it "rotates the response each time" do
-      send_command("add @iamvery to reviews")
-      send_command("add @zacstewart to reviews")
+      send_command("add iamvery to reviews")
+      send_command("add zacstewart to reviews")
 
       send_command("review me")
-      expect(replies.last).to eq("@iamvery")
+      expect(replies.last).to eq("iamvery")
 
       send_command("review me")
-      expect(replies.last).to eq("@zacstewart")
+      expect(replies.last).to eq("zacstewart")
     end
   end
 
@@ -71,28 +71,28 @@ describe Lita::Handlers::Reviewme, lita_handler: true do
 
       url = "https://github.com/iamvery/lita-reviewme/pull/5"
 
-      send_command("add @iamvery to reviews")
+      send_command("add iamvery to reviews")
       send_command("review #{url}")
 
-      expect(replies.last).to eq("I couldn't post a comment. (Are the permissions right?) @iamvery: :eyes: #{url}")
+      expect(replies.last).to eq("I couldn't post a comment. (Are the permissions right?) iamvery: :eyes: #{url}")
     end
   end
 
   describe "#display_reviewers" do
     it "responds with list of reviewers" do
-      send_command("add @iamvery to reviews")
-      send_command("add @zacstewart to reviews")
+      send_command("add iamvery to reviews")
+      send_command("add zacstewart to reviews")
       send_command("reviewers")
 
-      expect(reply).to eq("@zacstewart, @iamvery")
+      expect(reply).to eq("zacstewart, iamvery")
     end
   end
 
   describe "#mention_reviewer" do
     it "mentions a reviewer in chat with the given URL" do
-      send_command("add @iamvery to reviews")
+      send_command("add iamvery to reviews")
       send_command("review https://bitbucket.org/user/repo/pull-requests/123")
-      expect(replies.last).to eq("@iamvery: :eyes: https://bitbucket.org/user/repo/pull-requests/123")
+      expect(replies.last).to eq("iamvery: :eyes: https://bitbucket.org/user/repo/pull-requests/123")
     end
   end
 end


### PR DESCRIPTION
## Problem

Slack tries to be smart with @mentions. If it corresponds to a slack user, the value input in the reviewers rotation is actually their slack user id.

See Travis below for example.

![screen shot 2015-04-29 at 11 19 35 am](https://cloud.githubusercontent.com/assets/79619/7395762/b7c59e76-ee61-11e4-868e-45fbc053d964.png)

## Solution

Only prepend "@" for the GH mentions. There really isn't any meaningful semantic outside that case. Looking forward it might be nice to integrate this more with `Lita::User`. See #29 

Also worth noting this will require me to rebuild the current rotation, but it's not really a big deal since it's such a small set.