### PR TITLE
Prevent assigning someone to review their own GitHub PR

### DIFF
--- a/lib/lita/handlers/reviewme.rb
+++ b/lib/lita/handlers/reviewme.rb
@@ -85,7 +85,15 @@ module Lita
       def comment_on_github(response, room: get_room(response))
         repo = response.match_data[:repo]
         id = response.match_data[:id]
+
         reviewer = next_reviewer(room)
+        begin
+          pull_request = github_client.pull_request(repo, id)
+          owner = pull_request.user.login
+          reviewer = next_reviewer(room) if owner == reviewer
+        rescue Octokit::Error
+          response.reply("Unable to check who issued the pull request. Sorry if you end up being assigned your own PR!")
+        end
         comment = github_comment(reviewer)
 
         begin

--- a/spec/lita/handlers/reviewme_spec.rb
+++ b/spec/lita/handlers/reviewme_spec.rb
@@ -52,14 +52,13 @@ describe Lita::Handlers::Reviewme, lita_handler: true do
   end
 
   describe "#comment_on_github" do
+    let(:repo) { "gh_user/repo" }
+    let(:id) { "123" }
     let(:pr) do
       OpenStruct.new({ user: OpenStruct.new({ login: "pr-owner" }) })
     end
 
     it "posts comment on github" do
-      repo = "gh_user/repo"
-      id = "123"
-
       expect_any_instance_of(Octokit::Client).to receive(:add_comment)
         .with(repo, id, ":eyes: @iamvery")
 
@@ -70,9 +69,6 @@ describe Lita::Handlers::Reviewme, lita_handler: true do
     end
 
     it "skips assigning to the GitHub PR owner" do
-      repo = "gh_user/repo"
-      id = "123"
-
       expect_any_instance_of(Octokit::Client).to receive(:pull_request)
         .with(repo, id).and_return(pr)
       expect_any_instance_of(Octokit::Client).to receive(:add_comment)

--- a/spec/lita/handlers/reviewme_spec.rb
+++ b/spec/lita/handlers/reviewme_spec.rb
@@ -72,7 +72,7 @@ describe Lita::Handlers::Reviewme, lita_handler: true do
       send_command("add iamvery to reviews")
       send_command("review https://github.com/#{repo}/pull/#{id}")
 
-      expect(replies.last).to eq("iamvery should be on it...")
+      expect(reply).to eq("iamvery should be on it...")
     end
 
     it "skips assigning to the GitHub PR owner" do
@@ -85,7 +85,7 @@ describe Lita::Handlers::Reviewme, lita_handler: true do
       send_command("add iamvery to reviews")
       send_command("review https://github.com/#{repo}/pull/#{id}")
 
-      expect(replies.last).to eq("iamvery should be on it...")
+      expect(reply).to eq("iamvery should be on it...")
     end
 
     it "handles errors gracefully" do
@@ -97,7 +97,7 @@ describe Lita::Handlers::Reviewme, lita_handler: true do
       send_command("add iamvery to reviews")
       send_command("review #{url}")
 
-      expect(replies.last).to eq("I couldn't post a comment. (Are the permissions right?) iamvery: :eyes: #{url}")
+      expect(reply).to eq("I couldn't post a comment. (Are the permissions right?) iamvery: :eyes: #{url}")
     end
   end
 

--- a/spec/lita/handlers/reviewme_spec.rb
+++ b/spec/lita/handlers/reviewme_spec.rb
@@ -81,7 +81,7 @@ describe Lita::Handlers::Reviewme, lita_handler: true do
       expect_any_instance_of(Octokit::Client).to receive(:add_comment)
         .with(repo, id, ":eyes: @iamvery")
 
-      send_command("add pr-owner to reviews")
+      send_command("add #{pr.user.login} to reviews")
       send_command("add iamvery to reviews")
       send_command("review https://github.com/#{repo}/pull/#{id}")
 

--- a/spec/lita/handlers/reviewme_spec.rb
+++ b/spec/lita/handlers/reviewme_spec.rb
@@ -78,14 +78,16 @@ describe Lita::Handlers::Reviewme, lita_handler: true do
     it "skips assigning to the GitHub PR owner" do
       expect_any_instance_of(Octokit::Client).to receive(:pull_request)
         .with(repo, id).and_return(pr)
+
+      expected_reviewer = 'NOT THE PR OWNER'
       expect_any_instance_of(Octokit::Client).to receive(:add_comment)
-        .with(repo, id, ":eyes: @iamvery")
+        .with(repo, id, ":eyes: @#{expected_reviewer}")
 
       send_command("add #{pr.user.login} to reviews")
-      send_command("add iamvery to reviews")
+      send_command("add #{expected_reviewer} to reviews")
       send_command("review https://github.com/#{repo}/pull/#{id}")
 
-      expect(reply).to eq("iamvery should be on it...")
+      expect(reply).to eq("#{expected_reviewer} should be on it...")
     end
 
     it "handles errors gracefully" do


### PR DESCRIPTION
Grabs the PR's info before assigning a reviewer, and grabs the next reviewer if its first draw turned out to be the user that opened the PR in the first place.