### PR TITLE
PM responses that include a list of reviewers

### DIFF
--- a/lib/lita/handlers/reviewme.rb
+++ b/lib/lita/handlers/reviewme.rb
@@ -73,7 +73,7 @@ module Lita
 
       def display_reviewers(response)
         reviewers = redis.lrange(REDIS_LIST, 0, -1)
-        response.reply(reviewers.join(', '))
+        response.reply_privately(reviewers.join(', '))
       end
 
       def generate_assignment(response)


### PR DESCRIPTION
People keep getting pinged by mentions in the event their GitHub username includes one of their mention words (like me, since my GitHub username includes my first name :) ).

A workaround is to PM the sender a response like:

> **nerdbot:** reviewers for #ROOM: moe, larry, curly

The key bit is including the #ROOM context, since reviewers are per-room (for now, anyway).