### PR TITLE
Loosen dependency requirement for octokit

### DIFF
--- a/lita-reviewme.gemspec
+++ b/lita-reviewme.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "lita", ">= 3.1"
-  spec.add_runtime_dependency "octokit", "~> 3.7"
+  spec.add_runtime_dependency "octokit", [">= 3.0", "<5.0"]
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "fakeredis"


### PR DESCRIPTION
I ran the specs and they all passed. I also comparered the [two](https://github.com/iamvery/lita-reviewme/blob/c55cfca4e25181a5eb63696e63fa5dc033b869c6/lib/lita/handlers/reviewme.rb#L93) [places](https://github.com/iamvery/lita-reviewme/blob/c55cfca4e25181a5eb63696e63fa5dc033b869c6/lib/lita/handlers/reviewme.rb#L102) the use octokit and it would appear that the API hasn't changed for either.

Why:

* Version four has been out for over six months
* Another [Github related Lita extension](https://rubygems.org/gems/lita-github-web-hooks-core) is requiring version 4
