### PR TITLE
Support for sending private messages to reviewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ config.handlers.reviewme.github_access_token = ENV["GITHUB_ACCESS_TOKEN"]
 >
 > **Nerdbot** added kyfast to reviews
 
+### Include chat handle when adding reviewer
+When adding a reviewer you may supply the reviewers chat handle (often different from GitHub handle) by appending a `:` and the users chat handle. If a reviewers chat handle is supplied they will receive a private message when they have been assigned to review a pull request.
+
+> **Jay H.** Nerdbot: add johnallen3d:john.allen to reviews
+>
+> **Nerdbot** added johnallen3d (@john.allen) to reviews
+
 ### Remove a name from the review rotation
 
 > **Jay H.** Nerdbot: remove kyfast from reviews

--- a/lib/lita-reviewme.rb
+++ b/lib/lita-reviewme.rb
@@ -1,4 +1,5 @@
 require "lita"
+require "lita-reviewme/reviewer"
 
 Lita.load_locales Dir[File.expand_path(
   File.join("..", "..", "locales", "*.yml"), __FILE__

--- a/lib/lita-reviewme/reviewer.rb
+++ b/lib/lita-reviewme/reviewer.rb
@@ -1,0 +1,18 @@
+module LitaReviewme
+  class Reviewer
+    attr_reader :key, :github_username, :chat_handle
+
+    def initialize(key)
+      @key = key
+      @github_username, @chat_handle = key.split(':')
+    end
+
+    def to_s
+      github_username
+    end
+
+    def self.from_response(response)
+      new(response.matches.flatten.first)
+    end
+  end
+end

--- a/lib/lita/handlers/reviewme.rb
+++ b/lib/lita/handlers/reviewme.rb
@@ -62,21 +62,21 @@ module Lita
       )
 
       def add_reviewer(response, room: get_room(response))
-        reviewer = response.matches.flatten.first
-        ns_redis(room.id).lpush(REDIS_LIST, reviewer)
-        response.reply("added #{reviewer} to reviews")
+        reviewer = LitaReviewme::Reviewer.from_response(response)
+        ns_redis(room.id).lpush(REDIS_LIST, reviewer.key)
+        response.reply("added #{reviewer}#{" (@#{reviewer.chat_handle})" if reviewer.chat_handle} to reviews")
       end
 
       def remove_reviewer(response, room: get_room(response))
-        reviewer = response.matches.flatten.first
-        ns_redis(room.id).lrem(REDIS_LIST, 0, reviewer)
+        reviewer = LitaReviewme::Reviewer.from_response(response)
+        key = all_reviewers(room).find { |member| member.match(/^#{reviewer.key}(.*)/) }
+        ns_redis(room.id).lrem(REDIS_LIST, 0, key)
         response.reply("removed #{reviewer} from reviews")
       end
 
       def display_reviewers(response, room: get_room(response))
-        reviewers = ns_redis(room.id).lrange(REDIS_LIST, 0, -1)
         response.reply("Responding via private message...")
-        response.reply_privately("#{room.name}: #{reviewers.join(', ')}")
+        response.reply_privately("#{room.name}: #{all_reviewers(room).join(', ')}")
       end
 
       def generate_assignment(response, room: get_room(response))
@@ -92,7 +92,7 @@ module Lita
         begin
           pull_request = github_client.pull_request(repo, id)
           owner = pull_request.user.login
-          reviewer = next_reviewer(room) if owner == reviewer
+          reviewer = next_reviewer(room) if owner == reviewer.to_s
         rescue Octokit::Error
           response.reply("Unable to check who issued the pull request. Sorry if you end up being assigned your own PR!")
         end
@@ -101,6 +101,7 @@ module Lita
         begin
           github_client.add_comment(repo, id, comment)
           response.reply("#{reviewer} should be on it...")
+          notify(reviewer, response.match_data[:url])
         rescue Octokit::Error
           url = response.match_data[:url]
           response.reply("I couldn't post a comment. (Are the permissions right?) #{chat_mention(reviewer, url)}")
@@ -116,7 +117,7 @@ module Lita
       private
 
       def next_reviewer(room)
-        ns_redis(room.id).rpoplpush(REDIS_LIST, REDIS_LIST)
+        LitaReviewme::Reviewer.new(ns_redis(room.id).rpoplpush(REDIS_LIST, REDIS_LIST))
       end
 
       def github_comment(reviewer)
@@ -134,6 +135,19 @@ module Lita
       def get_room(response)
         room_id = response.message.source.room
         Lita::Room.find_by_id(room_id) || Lita::Room.new(room_id)
+      end
+
+      def all_reviewers(room)
+        ns_redis(room.id).lrange(REDIS_LIST, 0, -1)
+      end
+
+      def notify(reviewer, url)
+        return unless reviewer.chat_handle
+
+        user = Lita::User.find_by_mention_name(reviewer.chat_handle)
+        target = Lita::Source.new(user: user)
+
+        robot.send_message(target, "Hi there, you've been assigned to review #{url}.")
       end
 
       def ns_redis(namespace)

--- a/spec/lita-reviewme/reviewer_spec.rb
+++ b/spec/lita-reviewme/reviewer_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+describe LitaReviewme::Reviewer do
+  let(:github_username) { 'johnallen3d' }
+  let(:chat_handle) { 'john.allen' }
+
+  subject { described_class.new(github_username) }
+
+  it "uses the github username when serialized to string" do
+    expect(subject.to_s).to eq(github_username)
+  end
+
+  it "exposes the provided key" do
+    expect(subject.key).to eq(github_username)
+  end
+
+  it "exposes the github username" do
+    expect(subject.github_username).to eq(github_username)
+  end
+
+  describe "chat handle include" do
+    subject { described_class.new("#{github_username}:#{chat_handle}") }
+
+    it "parses the github username from the compound key" do
+      expect(subject.github_username).to eq(github_username)
+    end
+
+    it "parses the chat handle from the compound key" do
+      expect(subject.chat_handle).to eq(chat_handle)
+    end
+  end
+end


### PR DESCRIPTION
Not all users are subscribed to notifications from GitHub. This is taking a crack at #43.