### PR TITLE
Skip empty GitHub messages when no reviewers

### DIFF
--- a/lib/lita/handlers/reviewme.rb
+++ b/lib/lita/handlers/reviewme.rb
@@ -96,6 +96,7 @@ module Lita
         rescue Octokit::Error
           response.reply("Unable to check who issued the pull request. Sorry if you end up being assigned your own PR!")
         end
+        return response.reply('Sorry, no reviewers found') unless reviewer
         comment = github_comment(reviewer)
 
         begin

--- a/spec/lita/handlers/reviewme_spec.rb
+++ b/spec/lita/handlers/reviewme_spec.rb
@@ -75,6 +75,14 @@ describe Lita::Handlers::Reviewme, lita_handler: true do
       expect(reply).to eq("iamvery should be on it...")
     end
 
+    it "does NOT post comment on github when there are no reviewers" do
+      expect_any_instance_of(Octokit::Client).to_not receive(:add_comment)
+
+      send_command("review https://github.com/#{repo}/pull/#{id}")
+
+      expect(reply).to eq("Sorry, no reviewers found")
+    end
+
     it "skips assigning to the GitHub PR owner" do
       expect_any_instance_of(Octokit::Client).to receive(:pull_request)
         .with(repo, id).and_return(pr)


### PR DESCRIPTION
Otherwise sometimes you get an empty message like this:

>:eyes: @