### PR TITLE
Add support for Github "review requests"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# TODO: remove me after next release of the `octokit` gem
-gem "octokit", "github" => "octokit/octokit.rb"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
 
 gemspec
+
+# TODO: remove me after next release of the `octokit` gem
+gem "octokit", "github" => "octokit/octokit.rb"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ config.handlers.reviewme.github_comment_template = lamda do |reviewer, pull_requ
 end
 ```
 
+Your bot can assign a reviewer by adding a comment to the requested PR (default) or by [requesting a review](https://github.com/blog/2291-introducing-review-requests) (or both).
+
+```
+# your bot's lita_config.rb
+#
+# Note:
+# The following configuration will enable review requests and disable comments
+config.handlers.reviewme.github_request_review = true  # default (false)
+config.handlers.github_comment = false                 # default (true)
+```
+
 ## Usage
 
 ### See who is in the review rotation.

--- a/lib/lita-reviewme.rb
+++ b/lib/lita-reviewme.rb
@@ -7,11 +7,3 @@ Lita.load_locales Dir[File.expand_path(
 require "lita-reviewme/github"
 
 require "lita/handlers/reviewme"
-
-module Lita
-  module Reviewme
-    class NoReviewer < StandardError; end
-    class UnknownOwner < StandardError; end
-    class CannotPostComment < StandardError; end
-  end
-end

--- a/lib/lita-reviewme.rb
+++ b/lib/lita-reviewme.rb
@@ -4,4 +4,14 @@ Lita.load_locales Dir[File.expand_path(
   File.join("..", "..", "locales", "*.yml"), __FILE__
 )]
 
+require "lita-reviewme/github"
+
 require "lita/handlers/reviewme"
+
+module Lita
+  module Reviewme
+    class NoReviewer < StandardError; end
+    class UnknownOwner < StandardError; end
+    class CannotPostComment < StandardError; end
+  end
+end

--- a/lib/lita-reviewme/github.rb
+++ b/lib/lita-reviewme/github.rb
@@ -37,14 +37,17 @@ module Lita
       def assign_and_or_comment(reviewer)
         request_review(reviewer) if github_request_review
         add_comment(reviewer) if github_comment
-      rescue Octokit::Error
+      rescue Octokit::Error => e
+        puts e
         raise CannotPostComment
       end
 
       private
 
       def request_review(reviewer)
-        client.request_pull_request_review(repo, pr_id, [reviewer])
+        options = { accept: 'application/vnd.github.black-cat-preview' }
+
+        client.request_pull_request_review(repo, pr_id, [reviewer], options)
       end
 
       def add_comment(reviewer)

--- a/lib/lita-reviewme/github.rb
+++ b/lib/lita-reviewme/github.rb
@@ -1,0 +1,63 @@
+require 'delegate'
+
+module Lita
+  module Reviewme
+    class Github
+      extend Forwardable
+
+      attr_reader :config, :repo, :pr_id
+
+      delegate [
+        :github_access_token,
+        :github_comment_template,
+        :github_comment,
+        :github_request_review
+      ] => :config
+
+      def initialize(config, repo, pr_id)
+        @config = config
+        @repo = repo
+        @pr_id = pr_id
+      end
+
+      def client
+        @client ||= Octokit::Client.new(access_token: github_access_token)
+      end
+
+      def pull_request
+        @pull_request ||= client.pull_request(repo, pr_id)
+      end
+
+      def owner
+        pull_request.user.login
+      rescue Octokit::Error
+        raise UnknownOwner
+      end
+
+      def assign_and_or_comment(reviewer)
+        request_review(reviewer) if github_request_review
+        add_comment(reviewer) if github_comment
+      rescue Octokit::Error
+        raise CannotPostComment
+      end
+
+      private
+
+      def request_review(reviewer)
+        client.request_pull_request_review(repo, pr_id, [reviewer])
+      end
+
+      def add_comment(reviewer)
+        client.add_comment(repo, pr_id, comment(reviewer))
+      end
+
+      def comment(reviewer)
+        if github_comment_template.respond_to?(:call)
+          github_comment_template.call(reviewer, pull_request)
+        else
+          github_comment_template % { reviewer: "@#{reviewer}" }
+        end
+      end
+    end
+  end
+end

--- a/lib/lita/handlers/reviewme.rb
+++ b/lib/lita/handlers/reviewme.rb
@@ -8,6 +8,8 @@ module Lita
 
       config :github_access_token
       config :github_comment_template, default: DEFAULT_GITHUB_MSG
+      config :github_request_review, default: false
+      config :github_comment, default: true
 
       route(
         /add (.+) to reviews/i,
@@ -51,7 +53,7 @@ module Lita
 
       route(
         %r{review <?(?<url>(https://)?github.com/(?<repo>.+)/(pull|issues)/(?<id>\d+))>?}i,
-        :comment_on_github,
+        :review_on_github,
         command: true,
         help: { "review https://github.com/user/repo/pull/123" => "adds comment to GH issue requesting review" },
       )
@@ -86,28 +88,19 @@ module Lita
         response.reply(reviewer.to_s)
       end
 
-      def comment_on_github(response, room: get_room(response))
-        repo = response.match_data[:repo]
-        id = response.match_data[:id]
+      def review_on_github(response, room: get_room(response))
+        github = Lita::Reviewme::Github.new(config, response.match_data[:repo], response.match_data[:id])
+        reviewer = next_reviewer(room, github.owner)
 
-        reviewer = next_reviewer(room)
-        begin
-          pull_request = github_client.pull_request(repo, id)
-          owner = pull_request.user.login
-          reviewer = next_reviewer(room) if owner == reviewer
-        rescue Octokit::Error
-          response.reply("Unable to check who issued the pull request. Sorry if you end up being assigned your own PR!")
-        end
-        return response.reply('Sorry, no reviewers found') unless reviewer
-        comment = github_comment(reviewer, pull_request)
-
-        begin
-          github_client.add_comment(repo, id, comment)
-          response.reply("#{reviewer} should be on it...")
-        rescue Octokit::Error
-          url = response.match_data[:url]
-          response.reply("I couldn't post a comment. (Are the permissions right?) #{chat_mention(reviewer, url)}")
-        end
+        github.assign_and_or_comment(reviewer)
+        response.reply("#{reviewer} should be on it...")
+      rescue Lita::Reviewme::NoReviewer
+        response.reply('Sorry, no reviewers found')
+      rescue Lita::Reviewme::UnknownOwner
+        response.reply("Unable to check who issued the pull request. Sorry if you end up being assigned your own PR!")
+      rescue Lita::Reviewme::CannotPostComment
+        url = response.match_data[:url]
+        response.reply("I couldn't post a comment or request a reviewer. (Are the permissions right?) #{chat_mention(reviewer, url)}")
       end
 
       def mention_reviewer(response, room: get_room(response))
@@ -118,22 +111,16 @@ module Lita
 
       private
 
-      def next_reviewer(room)
-        ns_redis(room.id).rpoplpush(REDIS_LIST, REDIS_LIST)
-      end
+      def next_reviewer(room, owner = nil)
+        raise Lita::Reviewme::NoReviewer unless reviewer = ns_redis(room.id).rpoplpush(REDIS_LIST, REDIS_LIST)
 
-      def github_comment(reviewer, pull_request)
-        msg = config.github_comment_template
+        if reviewer == owner
+          raise Lita::Reviewme::NoReviewer if ns_redis(room.id).llen(REDIS_LIST) == 1
 
-        if msg.respond_to?(:call) # its a proc
-          msg.call(reviewer, pull_request)
-        else
-          msg % { reviewer: "@#{reviewer}" }
+          reviewer = next_reviewer(room, owner)
         end
-      end
 
-      def github_client
-        @github_client ||= Octokit::Client.new(access_token: config.github_access_token)
+        reviewer
       end
 
       def chat_mention(reviewer, url)

--- a/spec/lita-reviewme/github_spec.rb
+++ b/spec/lita-reviewme/github_spec.rb
@@ -1,0 +1,95 @@
+require "spec_helper"
+
+describe Lita::Reviewme::Github do
+  let(:repo) { "gh_user/repo" }
+  let(:id) { "123" }
+  let(:user) { OpenStruct.new(login: 'iamvery') }
+  let(:title) { 'PR Title' }
+  let(:pull_request) { OpenStruct.new(user: user, title: title) }
+  let(:github_comment_template) { ":eyes: %{reviewer}" }
+  let(:github_comment) { true }
+  let(:github_request_review) { false }
+
+  let(:config) do
+    OpenStruct.new(
+      github_access_token: 'access-token',
+      github_comment_template: github_comment_template,
+      github_comment: github_comment,
+      github_request_review: github_request_review
+    )
+  end
+
+  before do
+    allow_any_instance_of(Octokit::Client).to receive(:pull_request)
+      .and_return(pull_request)
+  end
+
+  subject { described_class.new(config, repo, id) }
+
+  describe "ownership" do
+    it "from the pull request" do
+      expect(subject.owner).to eq('iamvery')
+    end
+
+    describe "unexpected error" do
+      class User; def login; raise Octokit::Error; end; end
+
+      let(:user) { User.new }
+
+      it "raises an exception" do
+        expect { subject.owner }.to raise_error(Lita::Reviewme::Github::UnknownOwner)
+      end
+    end
+  end
+
+  describe "assignment" do
+    describe "requested not to comment or request reviewer" do
+      let(:github_comment) { false }
+
+      it "raises an exception" do
+        expect { subject.assign('iamvery') }.to raise_error(Lita::Reviewme::Github::CannotPostComment)
+      end
+    end
+
+    describe "via review request" do
+      let(:github_comment) { false }
+      let(:github_request_review) { true }
+
+      it "uses the request review api" do
+        expect_any_instance_of(Octokit::Client).to receive(:request_pull_request_review)
+          .with(repo, id, ['iamvery'], {:accept=>"application/vnd.github.black-cat-preview"})
+
+        subject.assign('iamvery')
+      end
+    end
+
+    describe "via comment api" do
+      describe "with a string" do
+        it "evaluates template" do
+          expect_any_instance_of(Octokit::Client).to receive(:add_comment)
+            .with(repo, id, ":eyes: @iamvery")
+
+          subject.assign('iamvery')
+        end
+      end
+
+      describe "with a proc" do
+        let(:github_comment_template) do
+          lambda do |reviewer, pull_request|
+            "hey @#{reviewer}, this is from a lambda! :tada: #{title}"
+          end
+        end
+
+        it "executes a proc if specified in `config.github_comment_template`" do
+          expected_msg = "hey @iamvery, this is from a lambda! :tada: #{title}"
+
+          expect_any_instance_of(Octokit::Client).to receive(:add_comment)
+            .with(repo, id, expected_msg)
+
+          subject.assign('iamvery')
+        end
+      end
+    end
+  end
+end
+

--- a/spec/lita/handlers/reviewme_spec.rb
+++ b/spec/lita/handlers/reviewme_spec.rb
@@ -8,9 +8,9 @@ describe Lita::Handlers::Reviewme, lita_handler: true do
   it { is_expected.to route_command("remove reviewer iamvery").to :remove_reviewer }
   it { is_expected.to route_command("reviewers").to :display_reviewers }
   it { is_expected.to route_command("review me").to :generate_assignment }
-  it { is_expected.to route_command("review https://github.com/user/repo/pull/123").to :comment_on_github }
-  it { is_expected.to route_command("review <https://github.com/user/repo/pull/123>").to :comment_on_github }
-  it { is_expected.to route_command("review https://github.com/user/repo/issues/123").to :comment_on_github }
+  it { is_expected.to route_command("review https://github.com/user/repo/pull/123").to :review_on_github }
+  it { is_expected.to route_command("review <https://github.com/user/repo/pull/123>").to :review_on_github }
+  it { is_expected.to route_command("review https://github.com/user/repo/issues/123").to :review_on_github }
   it { is_expected.to route_command("review https://bitbucket.org/user/repo/pull-requests/123").to :mention_reviewer }
   it { is_expected.to route_command("review <https://bitbucket.org/user/repo/pull-requests/123>").to :mention_reviewer }
 
@@ -52,7 +52,7 @@ describe Lita::Handlers::Reviewme, lita_handler: true do
     end
   end
 
-  describe "#comment_on_github" do
+  describe "#review_on_github" do
     let(:repo) { "gh_user/repo" }
     let(:id) { "123" }
     let(:pr) do
@@ -122,6 +122,16 @@ describe Lita::Handlers::Reviewme, lita_handler: true do
       expect(reply).to eq("iamvery should be on it...")
     end
 
+    it "doesn't get stuck if requester is only reviewer" do
+      expect_any_instance_of(Octokit::Client).to receive(:pull_request)
+        .with(repo, id).and_return(pr)
+
+      send_command("add #{pr.user.login} to reviews")
+      send_command("review https://github.com/#{repo}/pull/#{id}")
+
+      expect(reply).to eq('Sorry, no reviewers found')
+    end
+
     it "skips assigning to the GitHub PR owner" do
       expect_any_instance_of(Octokit::Client).to receive(:pull_request)
         .with(repo, id).and_return(pr)
@@ -146,7 +156,29 @@ describe Lita::Handlers::Reviewme, lita_handler: true do
       send_command("add iamvery to reviews")
       send_command("review #{url}")
 
-      expect(reply).to eq("I couldn't post a comment. (Are the permissions right?) iamvery: :eyes: #{url}")
+      expect(reply).to eq("I couldn't post a comment or request a reviewer. (Are the permissions right?) iamvery: :eyes: #{url}")
+    end
+
+    describe "review requests" do
+      before do
+        subject.config.github_comment = false
+        subject.config.github_request_review = true
+      end
+
+      after do
+        subject.config.github_request_review = false
+        subject.config.github_comment = true
+      end
+
+      it "requests a review if enabled" do
+        expect_any_instance_of(Octokit::Client).to receive(:request_pull_request_review)
+          .with(repo, id, ['iamvery'])
+
+        send_command("add iamvery to reviews")
+        send_command("review https://github.com/#{repo}/pull/#{id}")
+
+        expect(reply).to eq("iamvery should be on it...")
+      end
     end
   end
 

--- a/spec/lita/handlers/reviewme_spec.rb
+++ b/spec/lita/handlers/reviewme_spec.rb
@@ -172,7 +172,7 @@ describe Lita::Handlers::Reviewme, lita_handler: true do
 
       it "requests a review if enabled" do
         expect_any_instance_of(Octokit::Client).to receive(:request_pull_request_review)
-          .with(repo, id, ['iamvery'])
+          .with(repo, id, ['iamvery'], {:accept=>"application/vnd.github.black-cat-preview"})
 
         send_command("add iamvery to reviews")
         send_command("review https://github.com/#{repo}/pull/#{id}")


### PR DESCRIPTION
I've taken a crack at [adding support for Review Requests](https://github.com/iamvery/lita-reviewme/issues/48) and did a little [refactoring](https://github.com/iamvery/lita-reviewme/issues/52) along the way. 

Changes include:

* Adds a config setting to enable review requests (defaults to `false`)
* Adds a config setting to enable comments (defaults to `true`)
* Allows for both a traditional comment and review request
* Introduces a `class` to encapsulate interactions with Github
* Refactors `#review_on_github` exceptions are handles as such

As discussed in #48 this includes bundling `master` of octokit because the changes that include review requests have not yet been released. Perhaps it would be best to leave this open until that happens?

Resolves #48 
Resolves #52 
